### PR TITLE
Fixes for rpgen-native case and build

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -64,11 +64,14 @@ IFS=$OIFS
 
 umask 0022
 #It is against policy to set both $ISSUE and $OVERRIDES in the buildbot ui
-if [[ $ISSUE != 'None' && $OVERRIDES == 'None' ]]; then
-    OVERRIDES=$( ./build_for_issue.sh $ISSUE )
-else
+if [[ $ISSUE != 'None' && $OVERRIDES != 'None' ]]; then
     echo "Cannot pass both a Jira ticket and custom repository overrides to build from."
     exit -1
+elif [[ $ISSUE != 'None' && $OVERRIDES == 'None' ]]; then
+    echo "Building from Jira Issue."
+    OVERRIDES=$( ./build_for_issue.sh $ISSUE )
+else
+    echo "Not building from Jira Issue."
 fi
 cd build
 #Extra case for openxt override

--- a/build/engage_srcrevs.sh
+++ b/build/engage_srcrevs.sh
@@ -21,7 +21,14 @@ function do_overrides () {
 		short_nm="${short_nm%.*}" #Strip ".bb"
 		if [ $short_nm == "dm-agent" ] || [ $short_nm == "dm-wrapper" ];
    		then 
-        	echo "SRCREV_pn-$short_nm-stubdom=\"$srcrev\"" >> build/conf/local.conf;
+        		echo "SRCREV_pn-$short_nm-stubdom=\"$srcrev\"" >> build/conf/local.conf;
+	  	fi  
+		if [ $short_nm == "xenclient-rpcgen" ];
+   		then 
+	        	echo "SRCREV_pn-$short_nm-native=\"$srcrev\"" >> build/conf/local.conf;
+        	    	echo "OPENXT_GIT_MIRROR_pn-$short_nm-native=\"$gitr\"" >> build/conf/local.conf
+			echo "OPENXT_GIT_PROTOCOL_pn-$short_nm-native=\"git\"" >> build/conf/local.conf
+			echo "OPENXT_BRANCH_pn-$short_nm-native=\"$branch\"" >> build/conf/local.conf
 	    fi  
         #We've cloned into xenclient-oe already.
     	if [ ! $name == "xenclient-oe" ];


### PR DESCRIPTION
build.sh:  
* Logic fix for building from jira issue in if statement

engage_srcrevs.sh:
  * Add case for rpcgen-native. Causing problem with fetcher
    since its not a physical recipe and not overridden normally.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>